### PR TITLE
Added method to get predictions, added handling of out-of-domain tags

### DIFF
--- a/src/simplebilty.py
+++ b/src/simplebilty.py
@@ -473,6 +473,13 @@ class SimpleBiltyTagger(object):
 
         return correct, total
 
+    def get_predictions(self, test_X):
+        predictions = []
+        for word_indices, word_char_indices in test_X:
+            output = self.predict(word_indices, word_char_indices)
+            predictions += [int(np.argmax(o.value())) for o in output]
+        return predictions
+
     def get_train_data_from_instances(self, train_words, train_tags):
         """
         Extension of get_train_data method. Extracts training data from two arrays of word and label lists.

--- a/src/simplebilty.py
+++ b/src/simplebilty.py
@@ -387,7 +387,10 @@ class SimpleBiltyTagger(object):
 
         for (words, tags) in zip(dev_words, dev_tags):
             word_indices, word_char_indices = self.get_features(words)
-            tag_indices = [self.tag2idx.get(tag) for tag in tags]
+            # if tag does not exist in source domain tags, return as default
+            # first idx outside of dictionary
+            tag_indices = [self.tag2idx.get(
+                tag, len(self.tag2idx)) for tag in tags]
             X.append((word_indices, word_char_indices))
             Y.append(tag_indices)
             org_X.append(words)


### PR DESCRIPTION
So that we cannot only compute accuracy but also other metrics such as F1, I've added a function that returns a flattened list of predictions.
Currently, `None` is assigned in the `get_data_as_indices_from_instances` method whenever a tag did not exist in the training data. As `sklearn`'s evaluation functions do not work with `None` predictions, I've changed this to instead assign the length of the tag dictionary as default index.