### PR TITLE
Changes for temporal ensembling

### DIFF
--- a/src/simplebilty.py
+++ b/src/simplebilty.py
@@ -230,10 +230,14 @@ class SimpleBiltyTagger(object):
                     # unlabeled sequences; we skip the supervised loss for these
                     loss = dynet.scalarInput(0)
                 else:
-                    # use average instead of sum here so long sequences are not
-                    # preferred and so it can be combined with aux loss
-                    loss = dynet.average([self.pick_neg_log(pred,gold) for
-                                          pred, gold in zip(output, y)])
+                    if trg_vectors:
+                        # use average instead of sum here so long sequences are not
+                        # preferred and so it can be combined with aux loss
+                        loss = dynet.average([self.pick_neg_log(pred,gold) for
+                                              pred, gold in zip(output, y)])
+                    else:
+                        loss = dynet.esum([self.pick_neg_log(pred,gold) for
+                                              pred, gold in zip(output, y)])
 
                 if trg_vectors is not None:
                     # the consistency loss in temporal ensembling is used for


### PR DESCRIPTION
- Added target vectors and weight for unsupervised loss of temporal ensembling.
- Replaced sum with average in supervised loss. Sum might weight longer sequences more heavily but difference should be small. Average should be used so that weight of unsupervised loss is meaningful.
- Unsupervised loss is used for both supervised and unsupervised input. Authors of temporal ensembling show that this improves performance even for supervised classification.
- Added option to output soft labels (here: the softmax probability distribution) from the `get_predictions` method as we need these for temporal ensembling.

cc @bplank